### PR TITLE
Fixed  #24 where Twitter(X) logo was not visible on desktop

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -57,7 +57,8 @@ const Footer = () => {
 						<LinkedinIcon size={32} round />
 					</LinkedinShareButton>
 					<TwitterShareButton
-						url={'harmonycode.vercel.app/'} >
+						url={'harmonycode.vercel.app/'} 
+						style={{ marginRight: '40px' }}>
 						<TwitterIcon size={32} round />
 					</TwitterShareButton>
 				</div>


### PR DESCRIPTION
Fixed #24 : 
Fix UI: The Twitter(X) logo is not visible on desktop yet it is when seen on a mobile devices .
by:
add border to the Twitter(X) logo/button