### PR TITLE
chore(ci): auto-comment on new issues with welcome + Discord link

### DIFF
--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -1,0 +1,31 @@
+name: Issue Auto Reply
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.issue.number;
+            const body = `Thank you for raising this issue! Our team will review it soon. 
+
+For more queries or discussions or approval of requests, please join the Discord server for further discussion: [Discord Link](https://discord.com/invite/Yn9g6KuWyA)`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });
+
+- name: GitHub Script
+  uses: actions/github-script@v8

--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   comment:
-    if: github.event_name == 'issues' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: Add welcome comment


### PR DESCRIPTION
# GitHub Actions: Auto-Reply to New Issues

## Description
Adds a GitHub Actions workflow to automatically comment on newly opened issues with a welcome message and a Discord invite link.

## File
`.github/workflows/issue-auto-reply.yml`

## Trigger
```yaml
on:
  issues:
    types: [opened]

permissions:
  issues: write
Thank you for raising this issue! Our team will review it soon.
For more queries or discussions or approval of requests, please join the Discord server for further discussion: Discord Link
